### PR TITLE
Allow multiple uploads

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -170,11 +170,16 @@ func batchTransformation(mapEntries map[string][]string, batchOperations []map[s
 }
 func findField(operations interface{}, entryPaths []string) map[string]interface{} {
 	for i := 0; i < len(entryPaths); i++ {
-		if arr, ok := operations.([]map[string]interface{}); ok {
-			operations = arr[i]
-			return findField(operations, entryPaths)
+		if arr, ok := operations.([]interface{}); ok {
+			index, err := strconv.Atoi(entryPaths[i])
+			if err != nil {
+				panic("non-integer index provided for array value")
+			}
+			operations = arr[index]
 		} else if op, ok := operations.(map[string]interface{}); ok {
 			operations = op[entryPaths[i]]
+		} else {
+			panic("invalid operation mapping")
 		}
 	}
 	return operations.(map[string]interface{})


### PR DESCRIPTION
Fixes #1.

- Fix 1: When the operations JSON is unmarshalled, arrays are typed `[]interface{}` not the expected `[]map[string]interface{}`, so the if-branch relating to arrays on L173 is never called. The more specific typing isn't actually required so I've just updated the type assertion to `operations.([]interface{})`.
- Fix 2: The indexing on L174 doesn't make sense; the value of `entryPaths[i]` is what we want (same as L177).